### PR TITLE
Fix #1: map UniqueConstraintError to ConflictError on product create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 logs/
 .env
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Assistant boundaries
+
+- **Do not read `.env`.** It contains secrets. If a config value is needed, infer it from `src/config/*.ts`, ask the user, or reference the variable name without its value.
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Dev server (auto-runs `docker compose up -d` via `predev`) | `npm run dev` |
+| Build to `dist/` | `npm run build` |
+| Run production build | `npm start` |
+| Run all tests | `npm test` |
+| Run a single test file | `npx jest __tests__/unit/product.service.test.ts` |
+| Run tests matching a name | `npx jest -t "duplicate"` |
+| Seed 10,000 products | `npm run seed` |
+
+The server requires a `.env` with PostgreSQL connection vars (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_HOST`, `POSTGRES_PORT`) and `JWT_SECRET`. `JWT_SECRET` is loaded in `src/config/auth.ts` and throws on startup if missing. `JWT_EXPIRES_IN` is in seconds (default 900 = 15 min); refresh token lifetime is hard-coded to 7 days.
+
+Tables are auto-created on startup via `sequelize.sync()` in `src/config/db.ts` — there are no migrations.
+
+Jest is configured (`jest.config.ts`) with `ts-jest`, `testMatch: **/__tests__/**/*.test.ts`, and `setupFiles: ["dotenv/config"]`, so integration tests read the same `.env` as the server.
+
+## Architecture
+
+Strict layered architecture — each layer only talks to its direct neighbor:
+
+```
+Routes → Middleware → Controllers → Services → Repositories → Sequelize/Postgres
+```
+
+Controllers never touch the database; repositories never send HTTP responses. When adding a feature, create the file in each layer rather than shortcutting across them.
+
+### Cross-cutting patterns to preserve
+
+- **Zod as single source of truth** — `validators/*.validator.ts` schemas produce both the runtime validation (via the `validate(schema)` middleware factory in `src/middleware/validate.ts`) and the TypeScript DTO (`type ProductData = z.infer<typeof createProductSchema>`). Do not define a parallel TS interface for request bodies.
+- **DTO vs Entity split** — `ProductData` (client input) is distinct from `IProduct` (DB entity with `id`, `createdAt`, `updatedAt`). Do not accept entity fields on create/update endpoints.
+- **Typed error hierarchy** — Services throw `ConflictError`, `AuthenticationError`, `NotFoundError`, `ValidationError` from `src/errors/app-error.ts`. The global `errorHandler` maps them to HTTP codes via `instanceof`. Never use string matching on error messages, and never throw raw `Error` from services.
+- **Repository pattern** — All Sequelize calls live in `src/repositories/`. Services must not import Sequelize models directly. This is the seam unit tests mock.
+
+### Auth flow (dual-token with rotation)
+
+- Access token (JWT, 15 min default) → sent as `Authorization: Bearer <token>` on every request, validated by `middleware/auth.ts`.
+- Refresh token (opaque, 7 days) → stored in the `refresh_tokens` table. `/auth/refresh` is **single-use**: the old row is deleted and a new pair is issued. `/auth/logout` deletes the row.
+- Registration is hard-coded to `role: "customer"` in the Zod schema to prevent privilege escalation via the API — do not loosen this.
+
+### Route mounting
+
+Both `userRoutes` and `productRoutes` are mounted at `/api` in `src/app.ts`. The path prefix (`/auth`, `/products`) is defined inside each route file, not at mount time.
+
+### Security invariants (don't regress)
+
+- `express.json()` / `express.urlencoded()` are capped at `10kb`.
+- `orderby` on `GET /products` is validated against a whitelist — never pass user input straight to Sequelize `order`.
+- `search` is truncated to 100 chars.
+- User `password` is excluded from `findById` queries and all API responses.
+- bcrypt salt rounds = 10.
+
+## Testing strategy
+
+- `__tests__/unit/` — validators and services; the repository is mocked.
+- `__tests__/integration/` — full route via Supertest; repository is mocked (routes, middleware, controller, service are real).
+- There is no end-to-end test that hits Postgres; integration tests do **not** require the Docker DB to be running.

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/__tests__/unit/product.repository.test.ts
+++ b/__tests__/unit/product.repository.test.ts
@@ -1,0 +1,151 @@
+import {
+  UniqueConstraintError,
+  ValidationError as SequelizeValidationError,
+} from "sequelize";
+import { ConflictError } from "../../src/errors/app-error";
+
+jest.mock("../../src/models/product.model", () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(),
+    bulkCreate: jest.fn(),
+    findAll: jest.fn(),
+  },
+}));
+
+import Product from "../../src/models/product.model";
+import {
+  create,
+  createBulk,
+  findByNames,
+} from "../../src/repositories/product.repository";
+
+const mockedCreate = Product.create as jest.MockedFunction<typeof Product.create>;
+const mockedBulkCreate = Product.bulkCreate as jest.MockedFunction<typeof Product.bulkCreate>;
+const mockedFindAll = Product.findAll as jest.MockedFunction<typeof Product.findAll>;
+
+const validProduct = {
+  name: "Samsung Galaxy S24",
+  description: "Latest Samsung flagship",
+  price: 899.99,
+  category: "Smartphone",
+  brand: "Samsung",
+  model: "Galaxy S24",
+  year: 2024,
+  sku: "ABC1234567",
+  quantity: 50,
+  image: "https://picsum.photos/seed/1/640/480",
+};
+
+const makeUniqueConstraintError = () =>
+  new UniqueConstraintError({
+    message: "Validation error",
+    errors: [],
+  });
+
+describe("product repository — unique constraint mapping", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("create", () => {
+    it("returns the created product on success (happy path)", async () => {
+      const saved = { id: "uuid-1", ...validProduct };
+      mockedCreate.mockResolvedValue(saved as never);
+
+      await expect(create(validProduct)).resolves.toBe(saved);
+      expect(mockedCreate).toHaveBeenCalledWith(validProduct);
+    });
+
+    it("maps Sequelize UniqueConstraintError to ConflictError (status 409)", async () => {
+      mockedCreate.mockRejectedValue(makeUniqueConstraintError());
+
+      await expect(create(validProduct)).rejects.toBeInstanceOf(ConflictError);
+      await expect(create(validProduct)).rejects.toMatchObject({
+        statusCode: 409,
+        message: "Product already exists",
+      });
+    });
+
+    it("does NOT map other Sequelize errors (e.g. ValidationError) — they propagate untouched", async () => {
+      const validationErr = new SequelizeValidationError("value too long", []);
+      mockedCreate.mockRejectedValue(validationErr);
+
+      await expect(create(validProduct)).rejects.toBe(validationErr);
+      await expect(create(validProduct)).rejects.not.toBeInstanceOf(ConflictError);
+    });
+
+    it("rethrows unrelated errors untouched", async () => {
+      const dbDown = new Error("connection refused");
+      mockedCreate.mockRejectedValue(dbDown);
+
+      await expect(create(validProduct)).rejects.toBe(dbDown);
+    });
+  });
+
+  describe("createBulk", () => {
+    it("returns the created products on success (happy path)", async () => {
+      const saved = [{ id: "uuid-1", ...validProduct }];
+      mockedBulkCreate.mockResolvedValue(saved as never);
+
+      await expect(createBulk([validProduct])).resolves.toBe(saved);
+      expect(mockedBulkCreate).toHaveBeenCalledWith([validProduct]);
+    });
+
+    it("forwards an empty input array without throwing", async () => {
+      mockedBulkCreate.mockResolvedValue([] as never);
+
+      await expect(createBulk([])).resolves.toEqual([]);
+      expect(mockedBulkCreate).toHaveBeenCalledWith([]);
+    });
+
+    it("maps Sequelize UniqueConstraintError to ConflictError (status 409)", async () => {
+      mockedBulkCreate.mockRejectedValue(makeUniqueConstraintError());
+
+      await expect(createBulk([validProduct])).rejects.toBeInstanceOf(ConflictError);
+      await expect(createBulk([validProduct])).rejects.toMatchObject({
+        statusCode: 409,
+        message: "One or more products already exist",
+      });
+    });
+
+    it("does NOT map other Sequelize errors (e.g. ValidationError) — they propagate untouched", async () => {
+      const validationErr = new SequelizeValidationError("value too long", []);
+      mockedBulkCreate.mockRejectedValue(validationErr);
+
+      await expect(createBulk([validProduct])).rejects.toBe(validationErr);
+      await expect(createBulk([validProduct])).rejects.not.toBeInstanceOf(ConflictError);
+    });
+
+    it("rethrows unrelated errors untouched", async () => {
+      const dbDown = new Error("connection refused");
+      mockedBulkCreate.mockRejectedValue(dbDown);
+
+      await expect(createBulk([validProduct])).rejects.toBe(dbDown);
+    });
+  });
+
+  describe("findByNames", () => {
+    it("queries Product.findAll with a WHERE name IN (...) clause and returns the rows", async () => {
+      const rows = [{ id: "uuid-1", name: "A" }, { id: "uuid-2", name: "B" }];
+      mockedFindAll.mockResolvedValue(rows as never);
+
+      await expect(findByNames(["A", "B"])).resolves.toBe(rows);
+      expect(mockedFindAll).toHaveBeenCalledTimes(1);
+
+      const arg = mockedFindAll.mock.calls[0]![0] as { where: { name: Record<symbol, unknown> } };
+      const nameFilter = arg.where.name;
+      const inOperatorSymbol = Object.getOwnPropertySymbols(nameFilter).find(
+        (s) => s.description === "in",
+      );
+      expect(inOperatorSymbol).toBeDefined();
+      expect(nameFilter[inOperatorSymbol!]).toEqual(["A", "B"]);
+    });
+
+    it("returns an empty array when no names match", async () => {
+      mockedFindAll.mockResolvedValue([] as never);
+
+      await expect(findByNames(["nope"])).resolves.toEqual([]);
+    });
+  });
+});

--- a/src/repositories/product.repository.ts
+++ b/src/repositories/product.repository.ts
@@ -1,6 +1,7 @@
-import { Op } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
 import Product, { ProductData } from "../models/product.model";
 import { ProductFilters } from "../services/product.services";
+import { ConflictError } from "../errors/app-error";
 
 export const findAll = async (
   offset: number,
@@ -49,9 +50,23 @@ export const findByNames = async (names: string[]) => {
 };
 
 export const create = async (data: ProductData) => {
-  return Product.create(data as Record<string, unknown>);
+  try {
+    return await Product.create(data as Record<string, unknown>);
+  } catch (err) {
+    if (err instanceof UniqueConstraintError) {
+      throw new ConflictError("Product already exists");
+    }
+    throw err;
+  }
 };
 
 export const createBulk = async (dataList: ProductData[]) => {
-  return Product.bulkCreate(dataList as Record<string, unknown>[]);
+  try {
+    return await Product.bulkCreate(dataList as Record<string, unknown>[]);
+  } catch (err) {
+    if (err instanceof UniqueConstraintError) {
+      throw new ConflictError("One or more products already exist");
+    }
+    throw err;
+  }
 };

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Map Sequelize `UniqueConstraintError` → `ConflictError` in `src/repositories/product.repository.ts` so concurrent duplicate-name creates return **409** instead of the generic **500** `"Internal server error"`. The catch covers both `create` and `createBulk`.
- Add `__tests__/unit/product.repository.test.ts` with 11 tests covering: happy path, the unique-constraint mapping, selectivity (other Sequelize errors pass through), empty bulk input, and the `findByNames` query shape.
- Add `tsconfig.test.json` + `__tests__/tsconfig.json` so Jest globals resolve in the IDE without pulling test files into the main `tsc` build output.
- Add `CLAUDE.md` with architecture notes, commands, and an assistant-boundaries section (`.env` is off-limits).
- Gitignore `CLAUDE.local.md` for per-user personal notes.

Closes #1.

## Before vs after

| Path | Before | After |
|---|---|---|
| Pre-check duplicate (common case) | 409 | 409 ✓ unchanged |
| Concurrent duplicate, DB-constraint wins | **500** | **409** ✓ |
| Unrelated DB failure (connection, etc.) | 500 | 500 ✓ unchanged |

## Test plan

- [x] `npx jest` — 4 suites / 58 tests pass (47 existing + 11 new).
- [x] `npx tsc` — main build compiles; no test files leak into `dist/`.
- [x] `npx tsc -p tsconfig.test.json` — tests type-check cleanly.
- [ ] Reviewer validation — fire two concurrent `POST /api/products` with the same `name` against a live Postgres and confirm the loser returns `409` with `{"message":"Product already exists"}` rather than `500`.

## Not in this PR (tracked separately)

- #7 — bulk path rejects the whole batch on intra-batch duplicates (investigating Sequelize `ignoreDuplicates` trade-offs before implementing).
- #2, #3, #4, #5, #6, #8, #9 — filed as follow-ups from the brainstorm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)